### PR TITLE
Show alertbox if an app is installed but not launchable

### DIFF
--- a/app/src/main/java/com/finnmglas/launcher/MainActivity.kt
+++ b/app/src/main/java/com/finnmglas/launcher/MainActivity.kt
@@ -1,7 +1,10 @@
 package com.finnmglas.launcher
 
 import android.annotation.SuppressLint
+import android.app.AlertDialog
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.util.DisplayMetrics
@@ -36,8 +39,7 @@ GestureDetector.OnDoubleTapListener {
     private val displayMetrics = DisplayMetrics()
 
     private fun getIntent(packageName: String): Intent? {
-        val pm = applicationContext.packageManager
-        val intent: Intent? = pm.getLaunchIntentForPackage(packageName)
+        val intent: Intent? = packageManager.getLaunchIntentForPackage(packageName)
         intent?.addCategory(Intent.CATEGORY_LAUNCHER)
         return intent
     }
@@ -49,11 +51,25 @@ GestureDetector.OnDoubleTapListener {
             applicationContext.startActivity(intent1)
             overridePendingTransition(0, 0)
         } else {
-            Toast.makeText(
-                this,
-                "Open settings to choose an app for this action",
-                Toast.LENGTH_SHORT
-            ).show()
+            if (isInstalled(packageName, this)){
+
+                AlertDialog.Builder(this)
+                    .setTitle("Can't open app")
+                    .setMessage("Want to change its settings ('add it to the apps screen')?")
+                    .setPositiveButton(android.R.string.yes,
+                        DialogInterface.OnClickListener { dialog, which ->
+                            openAppSettings(packageName, this)
+                        })
+                    .setNegativeButton(android.R.string.no, null)
+                    .setIcon(android.R.drawable.ic_dialog_info)
+                    .show()
+            } else {
+                Toast.makeText(
+                    this,
+                     "Open settings to choose an app for this action",
+                      Toast.LENGTH_SHORT
+                    ).show()
+                }
             }
         }
 

--- a/app/src/main/java/com/finnmglas/launcher/Settings.kt
+++ b/app/src/main/java/com/finnmglas/launcher/Settings.kt
@@ -1,19 +1,28 @@
 package com.finnmglas.launcher
 
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.core.content.ContextCompat.startActivity
 
 val none_msg = "None found"
 
 fun isInstalled(uri: String, context: Context): Boolean {
-    val pm: PackageManager = context.packageManager
     try {
-        pm.getPackageInfo(uri, PackageManager.GET_ACTIVITIES)
+        context.packageManager.getPackageInfo(uri, PackageManager.GET_ACTIVITIES)
         return true
     } catch (e: PackageManager.NameNotFoundException) {
     }
     return false
+}
+
+fun openAppSettings(pkg :String, context:Context){
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+    intent.data = Uri.parse("package:$pkg")
+    context.startActivity(intent)
 }
 
 fun loadSettings(sharedPref : SharedPreferences){

--- a/app/src/main/java/com/finnmglas/launcher/SettingsActivity.kt
+++ b/app/src/main/java/com/finnmglas/launcher/SettingsActivity.kt
@@ -98,9 +98,7 @@ class SettingsActivity : AppCompatActivity() {
                 .setPositiveButton(android.R.string.yes,
                     DialogInterface.OnClickListener { dialog, which ->
                         try {
-                            val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                            intent.data = Uri.parse("package:$packageName")
-                            startActivity(intent)
+                            openAppSettings(packageName, this)
                         } catch ( e : ActivityNotFoundException) {
                             val intent = Intent(android.provider.Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)
                             startActivity(intent)


### PR DESCRIPTION
There was a problem with opening the default App Finder.
The app was hidden but installed.
The added code will open the app info / settings if that happens.