### PR TITLE
Fix button appearance for older devices

### DIFF
--- a/app/src/main/java/com/finnmglas/launcher/MainActivity.kt
+++ b/app/src/main/java/com/finnmglas/launcher/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity(),
             when (currentTheme) {
                 "dark" -> R.style.darkTheme
                 "finn" -> R.style.finnmglasTheme
-                else -> R.style.finnmglasTheme
+                else -> R.style.customTheme
             }
         )
         setContentView(R.layout.activity_main)

--- a/app/src/main/java/com/finnmglas/launcher/SettingsActivity.kt
+++ b/app/src/main/java/com/finnmglas/launcher/SettingsActivity.kt
@@ -34,7 +34,7 @@ class SettingsActivity : AppCompatActivity() {
             when (getSavedTheme(this)) {
                 "dark" -> R.style.darkTheme
                 "finn" -> R.style.finnmglasTheme
-                else -> R.style.finnmglasTheme
+                else -> R.style.customTheme
             }
         )
 

--- a/app/src/main/java/com/finnmglas/launcher/extern/Functions.kt
+++ b/app/src/main/java/com/finnmglas/launcher/extern/Functions.kt
@@ -8,10 +8,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
-import android.graphics.Bitmap
-import android.graphics.BlendMode
-import android.graphics.BlendModeColorFilter
-import android.graphics.PorterDuff
+import android.graphics.*
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -325,6 +322,9 @@ fun getDominantColor(bitmap: Bitmap?): Int {
 fun setButtonColor(btn: Button, color: Int) {
     if (Build.VERSION.SDK_INT >= 29)
         btn.background.colorFilter = BlendModeColorFilter(color, BlendMode.MULTIPLY)
-    else
-        btn.background.setColorFilter(color, PorterDuff.Mode.MULTIPLY)
+    else {
+        // not setting it here, unable to find a good alternative
+        // I tried:
+        // btn.background.colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+    }
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -31,6 +31,16 @@
         <item name="android:windowAnimationStyle">@style/WindowFadeTransition</item>
     </style>
 
+    <!-- Custom theme -->
+    <style name="customTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:textColor">#ffffff</item>
+        <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Colored</item>
+        <item name="colorButtonNormal">#252827</item>
+
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowAnimationStyle">@style/WindowFadeTransition</item>
+    </style>
+
     <style name="AlertDialogCustom" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:textColor">#000000</item>
     </style>


### PR DESCRIPTION
+ Buttons on API < 29 now all have the same color for the customTheme
+ This can be worked on again, if someone figures out how to dynamically 
change button colors on older android APIs