### PR TITLE
Prevent theme colors from being equal

### DIFF
--- a/app/src/main/java/com/finnmglas/launcher/extern/Functions.kt
+++ b/app/src/main/java/com/finnmglas/launcher/extern/Functions.kt
@@ -7,7 +7,10 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
-import android.graphics.*
+import android.graphics.Bitmap
+import android.graphics.BlendMode
+import android.graphics.BlendModeColorFilter
+import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -17,6 +20,7 @@ import android.view.animation.*
 import android.widget.Button
 import android.widget.Toast
 import com.finnmglas.launcher.R
+import kotlin.math.roundToInt
 
 /** Variables for all of the app */
 var upApp = ""
@@ -316,5 +320,20 @@ fun setButtonColor(btn: Button, color: Int) {
         // not setting it here, unable to find a good alternative
         // I tried:
         // btn.background.colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+        // TODO at some point (or you do it now)
     }
+}
+
+// Taken from: https://stackoverflow.com/a/33072575/12787264
+fun manipulateColor(color: Int, factor: Float): Int {
+    val a = Color.alpha(color)
+    val r = (Color.red(color) * factor).roundToInt()
+    val g = (Color.green(color) * factor).roundToInt()
+    val b = (Color.blue(color) * factor).roundToInt()
+    return Color.argb(
+        a,
+        r.coerceAtMost(255),
+        g.coerceAtMost(255),
+        b.coerceAtMost(255)
+    )
 }

--- a/app/src/main/java/com/finnmglas/launcher/settings/SettingsFragmentTheme.kt
+++ b/app/src/main/java/com/finnmglas/launcher/settings/SettingsFragmentTheme.kt
@@ -111,6 +111,12 @@ class SettingsFragmentTheme : Fragment() {
                     dominantColor = palette.getDominantColor(ContextCompat.getColor(context!!, R.color.darkTheme_accent_color))
                     vibrantColor = palette.getVibrantColor(ContextCompat.getColor(context!!, R.color.darkTheme_accent_color))
 
+                    // never let dominantColor equal vibrantColor
+                    if(dominantColor == vibrantColor) {
+                        vibrantColor = manipulateColor(vibrantColor, 1.2F)
+                        dominantColor = manipulateColor(dominantColor, 0.8F)
+                    }
+
                     /* Save image Uri as string */
                     val editor: SharedPreferences.Editor = context!!.getSharedPreferences(
                         context!!.getString(R.string.preference_file_key), Context.MODE_PRIVATE).edit()


### PR DESCRIPTION
If `vibrantColor` is equal to `dominantColor`, dominant will be darkened 
by 20% and vibrant lightened by 20%